### PR TITLE
Fix straggling banner bearers added by Raise Your Banner

### DIFF
--- a/RealisticBattleAiModule/AiModule/AgentAi.cs
+++ b/RealisticBattleAiModule/AiModule/AgentAi.cs
@@ -575,7 +575,7 @@ namespace RBMAI
                     bannerNearbyEnemies.RemoveAll((Agent a) => a.IsRunningAway);
                     if (!bannerNearbyEnemies.Any())
                     {
-                        Agent firstUnit = ___Agent.Formation.GetFirstUnit();
+                        Agent firstUnit = ___Agent.Formation?.GetFirstUnit();
 
                         ___Agent.SetAutomaticTargetSelection(false);
 

--- a/RealisticBattleAiModule/AiModule/AgentAi.cs
+++ b/RealisticBattleAiModule/AiModule/AgentAi.cs
@@ -573,9 +573,24 @@ namespace RBMAI
                     // Fleeing routers run through our lines and end up within 5m; a banner bearer shouldn't chase-swing
                     // at them (it can't catch them = "attacking air"), so treat only non-routing enemies as a reason to fight.
                     bannerNearbyEnemies.RemoveAll((Agent a) => a.IsRunningAway);
-                    if (bannerNearbyEnemies.Count == 0)
+                    if (!bannerNearbyEnemies.Any())
                     {
-                        ___Agent.InvalidateTargetAgent();
+                        Agent firstUnit = ___Agent.Formation.GetFirstUnit();
+
+                        ___Agent.SetAutomaticTargetSelection(false);
+
+                        if (___Agent.GetDistanceTo(firstUnit) > 5f)
+                        {
+                            ___Agent.SetTargetAgent(firstUnit);
+                        }
+                        else
+                        {
+                            ___Agent.InvalidateTargetAgent();
+                        }
+                    }
+                    else
+                    {
+                        ___Agent.SetAutomaticTargetSelection(true);
                     }
                 }
                 //___Agent.MovementInputVector = new Vec2(30f, 30f);


### PR DESCRIPTION
- Change `Count` to `Any` as the latter is faster.
- Instead of constantly invalidating the banner bearer's target agent, set their target agent to the first unit in their formation.
- Automatic target selection needs to be disabled in order to set the banner bearer's target agent.
- The banner bearer will follow the first unit without straggling and without attacking the air.
- Invalidate the target agent when the banner bearer is within 5m of the first unit.